### PR TITLE
Bug: Local generator updates

### DIFF
--- a/localGenerator.js
+++ b/localGenerator.js
@@ -144,12 +144,12 @@ var exploreDir = function(dir) {
               var frequency = tokenInfo[1];
               // Token exclusion criteria:
               // - Empty string
-              // - Very long string (things bigger than dysdiachokinesis unlikely to be searched for...
+              // - Very long strings
               // - Strings containing more than 4 numbers (e.g., "a1413302")
               // - Strings containing over 5 letters and then >2 digits (e.g., "abstinence109")
               // - Strings starting with a letter followed by a digit and then >1 letters (e.g., "a8vator")
               // - Strings beginning in a single character followed by only digits
-              if (token === '' || token.length >= 20 || token.match(/\d\d\d\d/) || token.match(/[a-z]{5}\d\d+/) ||
+              if (token === '' || token.length >= 40 || token.match(/\d\d\d\d/) || token.match(/[a-z]{5}\d\d+/) ||
                   token.match(/[a-z]{1,2}\d+[a-z]+/) || token.match(/^[a-z]\d+$/)) {
                 continue
               } else if (token in invertedIndex) {

--- a/localGenerator.js
+++ b/localGenerator.js
@@ -104,13 +104,13 @@ var exploreDir = function(dir) {
     } else {
       // Example match: 
       // > matchObject
-      // [ 'Neuroanatomy Final Review!.txt.tokens',
-      //   'Neuroanatomy Final Review!',
+      // [ '05.25.16 Neuroanatomy Final Review!.txt.tokens',
+      //   '05.25.16 Neuroanatomy Final Review!',
       //   '.txt.tokens',
       //   index: 0,
       //   input: 'Neuroanatomy Final Review!.txt.tokens' 
       //   ]
-      var splitFile = file.match(/^([^.]+)(.*)$/);
+      var splitFile = file.match(/^(.*?)((?:\.[A-Za-z0-9]{3,6}){1,2})$/);
       if (splitFile != null) {
         var minusExtension = splitFile[1];
         var extension = splitFile[2];


### PR DESCRIPTION
Fix two bugs in localGenerator that led to incomplete search results.

The first commit raises the limit used to exclude tokens from invertedIndex.js. Earlier limits excluded useful tokens like `hyperparathyroidism`.

The second commit amends the regex used to detect filenames to handle files whose basename contains periods (e.g., '05.26.16_GI Cancer Flowsheet.xlsx').