### PR TITLE
Bug: Process queries similarly to tokens

### DIFF
--- a/local_prototype/resources/js/compass.js
+++ b/local_prototype/resources/js/compass.js
@@ -193,8 +193,13 @@ compass = (function() {
     // bigrams. Will have a second query array as a workaround
     var queryUnigrams = [];
     for (var i = 0; i < queryArray.length; i++) {
+      // In token processing, converted punctuation to spaces. Though
+      // we won't transform all punctuation, dashes may appear in
+      // queries such as 'beta-blocker' and should be converted here,
+      // as well
+      var q = queryArray[i].replace('-', ' ');
       // Need Array.push to update queryUnigrams in place
-      Array.prototype.push.apply(queryUnigrams, queryArray[i].split(/\s+/));
+      Array.prototype.push.apply(queryUnigrams, q.split(/\s+/));
     }
 
     // Should not use the unigrams when searching for title matches -


### PR DESCRIPTION
Queries containing punctuation (notably `-`) previously would not
match tokens that had gone through the token processing pipeline,
step one of which included transforming punctuation to spaces.

This commit converts the `-` character to a space; further changes
are likely unnecessary and can be added as they appear.